### PR TITLE
feat: add rust mcp bridge

### DIFF
--- a/rust_mcp_bridge/.gitignore
+++ b/rust_mcp_bridge/.gitignore
@@ -1,0 +1,20 @@
+# Rust
+/target/
+**/*.rs.bk
+*.pdb
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Environment
+.env
+.env.local
+
+# Logs
+*.log

--- a/rust_mcp_bridge/Cargo.toml
+++ b/rust_mcp_bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rs-utcp-bridge"
+name = "mcp-bridge-rs-utcp"
 version = "1.0.0"
 edition = "2021"
 description = "MCP bridge for Rust UTCP - exposes UTCP tools as MCP tools"

--- a/rust_mcp_bridge/Cargo.toml
+++ b/rust_mcp_bridge/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "rs-utcp-bridge"
+version = "1.0.0"
+edition = "2021"
+description = "MCP bridge for Rust UTCP - exposes UTCP tools as MCP tools"
+license = "MIT OR Apache-2.0"
+authors = ["Universal Tool Calling Protocol"]
+
+[dependencies]
+
+# Async runtime
+tokio = { version = "1.0", features = ["full"] }
+async-trait = "0.1"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+anyhow = "1.0"
+thiserror = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# For stdio communication
+tokio-util = { version = "0.7", features = ["codec"] }
+futures = "0.3"
+
+# UTCP client
+rs-utcp = "=0.2.1"

--- a/rust_mcp_bridge/README.md
+++ b/rust_mcp_bridge/README.md
@@ -1,0 +1,293 @@
+![MCP vs. UTCP](https://github.com/universal-tool-calling-protocol/.github/raw/main/assets/banner.png)
+
+# UTCP MCP Bridge (Rust)
+
+This **Rust UTCP bridge** enables seamless integration between UTCP tools and any MCP-based ecosystem, providing standard tool invocation, search, streaming, and provider registration functionalities.
+
+A lightweight Rust-based bridge that exposes **UTCP tools** as **MCP tools** — enabling any MCP-compatible client (Claude Desktop, Claude CLI, LLM runtimes implementing MCP) to call UTCP tools seamlessly.
+
+## Features
+
+This bridge lets you:
+
+- 🔌 Load UTCP providers dynamically from JSON configuration
+- 🛠 Call UTCP tools via MCP
+- 🔍 Search the UTCP tool registry
+- 🔄 Stream UTCP tool results over MCP
+- 🤝 Register new providers dynamically at runtime (planned)
+
+Designed with flexibility in mind, the bridge can power anything from local tool-automation setups to distributed LLM agent workflows.
+
+---
+
+## UTCP → MCP Tool Mapping
+
+| MCP Tool Name             | Description |
+|---------------------------|-------------|
+| `utcp_call_tool`          | Call any UTCP tool with arguments |
+| `utcp_search_tools`       | Fuzzy-search tools in UTCP registry |
+| `utcp_call_tool_stream`   | Stream responses from UTCP tools |
+| `utcp_register_provider`  | Register new UTCP provider at runtime (planned) |
+
+---
+
+## Installation
+
+### From Source
+
+```bash
+git clone https://github.com/universal-tool-calling-protocol/mcp-bridge-rs-utcp.git
+cd mcp-bridge-rs-utcp
+cargo build --release
+```
+
+### Install Globally
+
+To install the bridge globally so it can be used from anywhere:
+
+```bash
+# Copy to your local bin directory (recommended)
+cp target/release/mcp-bridge-rs-utcp ~/.local/bin/
+
+# OR copy to system bin (requires sudo)
+sudo cp target/release/mcp-bridge-rs-utcp /usr/local/bin/
+```
+
+Ensure `~/.local/bin` or `/usr/local/bin` is in your `PATH`.
+
+---
+
+## Usage
+
+### Quick Start
+
+```bash
+# Set the path to your UTCP providers file (optional)
+export UTCP_PROVIDERS_FILE=/path/to/providers.json
+
+# Run the bridge
+mcp-bridge-rs-utcp
+```
+
+### With Claude Desktop
+
+Add the following to your Claude Desktop MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "utcp-bridge": {
+      "command": "mcp-bridge-rs-utcp",
+      "env": {
+        "UTCP_PROVIDERS_FILE": "/absolute/path/to/providers.json"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Features
+
+### CodeMode
+
+The bridge includes **CodeMode** support, allowing you to execute inline Rhai scripts that can call UTCP tools. This enables complex logic and data processing directly within the MCP tool call.
+
+#### Example: Run Code
+
+```json
+{
+  "name": "utcp_run_code",
+  "arguments": {
+    "code": "let x = 10; x * 2",
+    "timeout": 1000
+  }
+}
+```
+
+#### Example: Call Tool from Code
+
+```json
+{
+  "name": "utcp_run_code",
+  "arguments": {
+    "code": "let weather = call_tool(\"get_weather\", #{\"city\": \"London\"}); weather"
+  }
+}
+```
+
+---
+
+## Configuration
+
+The bridge uses the `rs-utcp` configuration format. Create a `providers.json` file:
+
+```json
+{
+  "manual_call_templates": [
+    {
+      "call_template_type": "http",
+      "name": "weather_api",
+      "url": "https://api.weather.example.com/tools",
+      "http_method": "GET"
+    },
+    {
+      "call_template_type": "mcp",
+      "name": "file_tools",
+      "command": "python3",
+      "args": ["mcp_server.py"]
+    }
+  ],
+  "load_variables_from": [
+    {
+      "variable_loader_type": "dotenv",
+      "env_file_path": ".env"
+    }
+  ]
+}
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐
+│   MCP Client    │  (Claude Desktop, etc.)
+│  (JSON-RPC)     │
+└────────┬────────┘
+         │
+         │ stdio/SSE
+         ▼
+┌─────────────────┐
+│  MCP Bridge     │  (this project)
+│  (Rust)         │
+└────────┬────────┘
+         │
+         │ UTCP Protocol
+         ▼
+┌─────────────────┐
+│  UTCP Client    │  (rs-utcp)
+│                 │
+└────────┬────────┘
+         │
+         │ Various Transports
+         ▼
+┌─────────────────┐
+│  Tool Providers │
+│  (HTTP, gRPC,   │
+│   WebSocket,    │
+│   MCP, etc.)    │
+└─────────────────┘
+```
+
+---
+
+## Tool Examples
+
+### Call a UTCP Tool
+
+```json
+{
+  "name": "utcp_call_tool",
+  "arguments": {
+    "tool_name": "get_weather",
+    "arguments": {
+      "city": "San Francisco"
+    }
+  }
+}
+```
+
+### Search for Tools
+
+```json
+{
+  "name": "utcp_search_tools",
+  "arguments": {
+    "query": "weather",
+    "limit": 5
+  }
+}
+```
+
+### Stream Tool Results
+
+```json
+{
+  "name": "utcp_call_tool_stream",
+  "arguments": {
+    "tool_name": "generate_report",
+    "arguments": {
+      "topic": "AI trends"
+    }
+  }
+}
+```
+
+---
+
+## Development
+
+### Building
+
+```bash
+cargo build
+```
+
+### Running Tests
+
+```bash
+cargo test
+```
+
+### Running Locally
+
+```bash
+RUST_LOG=info cargo run
+```
+
+---
+
+## Comparison with Go Implementation
+
+This Rust implementation provides the same core functionality as the [Go UTCP MCP Bridge](https://github.com/universal-tool-calling-protocol/go-utcp-mcp-bridge), with the following differences:
+
+- ✅ **Performance**: Rust implementation offers better memory safety and performance
+- ✅ **Type Safety**: Leverages Rust's type system for more robust error handling
+- ✅ **CodeMode**: Inline code execution supported via Rhai engine
+- 🚧 **Chain Execution**: UTCP Chain support planned for future release
+
+---
+
+## Status
+
+This bridge is currently in **beta** status. The following features are implemented:
+
+- ✅ Tool calling
+- ✅ Tool search
+- ✅ Streaming support
+- ✅ CodeMode support
+- 🚧 Dynamic provider registration (in progress)
+- 🚧 Chain execution (planned)
+
+---
+
+## Related Projects
+
+- [rs-utcp](https://github.com/universal-tool-calling-protocol/rs-utcp) - Rust UTCP client library
+- [go-utcp](https://github.com/universal-tool-calling-protocol/go-utcp) - Go UTCP implementation
+- [go-utcp-mcp-bridge](https://github.com/universal-tool-calling-protocol/go-utcp-mcp-bridge) - Go MCP bridge
+
+---
+
+## License
+
+MIT OR Apache-2.0
+
+---
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.

--- a/rust_mcp_bridge/providers.example.json
+++ b/rust_mcp_bridge/providers.example.json
@@ -1,0 +1,24 @@
+{
+    "manual_call_templates": [
+        {
+            "call_template_type": "http",
+            "name": "weather_api",
+            "url": "https://api.weather.example.com/tools",
+            "http_method": "GET"
+        },
+        {
+            "call_template_type": "mcp",
+            "name": "file_tools",
+            "command": "python3",
+            "args": [
+                "mcp_server.py"
+            ]
+        }
+    ],
+    "load_variables_from": [
+        {
+            "variable_loader_type": "dotenv",
+            "env_file_path": ".env"
+        }
+    ]
+}

--- a/rust_mcp_bridge/src/main.rs
+++ b/rust_mcp_bridge/src/main.rs
@@ -1,0 +1,596 @@
+use anyhow::{Context, Result};
+use rs_utcp::config::UtcpClientConfig;
+use rs_utcp::plugins::codemode::{CodeModeArgs, CodeModeUtcp};
+use rs_utcp::repository::in_memory::InMemoryToolRepository;
+use rs_utcp::tag::tag_search::TagSearchStrategy;
+use rs_utcp::{UtcpClient, UtcpClientInterface};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tracing::{error, info};
+use std::path::PathBuf;
+
+/// JSON-RPC 2.0 Request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    id: Option<Value>,
+    method: String,
+    params: Option<Value>,
+}
+
+/// JSON-RPC 2.0 Response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+/// MCP Server Info
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServerInfo {
+    name: String,
+    version: String,
+}
+
+/// MCP Server Capabilities
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Value>,
+}
+
+/// MCP Tool Schema
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct McpTool {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(rename = "inputSchema")]
+    input_schema: Value,
+}
+
+/// The main bridge struct
+pub struct UtcpMcpBridge {
+    utcp_client: Arc<UtcpClient>,
+    utcp_code: Arc<CodeModeUtcp>,
+}
+
+impl UtcpMcpBridge {
+    /// Create a new bridge
+    pub async fn new(config: UtcpClientConfig) -> Result<Self> {
+        let repo = Arc::new(InMemoryToolRepository::new());
+        let strat = Arc::new(TagSearchStrategy::new(repo.clone(), 0.5));
+        
+        let utcp_client = Arc::new(
+            UtcpClient::new(config, repo, strat).await.context("Failed to create UTCP client")?
+        );
+
+        let utcp_code = Arc::new(CodeModeUtcp::new(utcp_client.clone()));
+
+        Ok(Self {
+            utcp_client,
+            utcp_code,
+        })
+    }
+
+    /// Get MCP tool definitions
+    fn get_tools() -> Vec<McpTool> {
+        vec![
+            McpTool {
+                name: "utcp_call_tool".to_string(),
+                description: Some("Call a UTCP tool by name with arguments".to_string()),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "tool_name": {
+                            "type": "string",
+                            "description": "Name of the UTCP tool to call"
+                        },
+                        "arguments": {
+                            "type": "object",
+                            "description": "Arguments to pass to the tool"
+                        }
+                    },
+                    "required": ["tool_name"]
+                }),
+            },
+            McpTool {
+                name: "utcp_search_tools".to_string(),
+                description: Some("Search for available UTCP tools".to_string()),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of results",
+                            "default": 10
+                        }
+                    },
+                    "required": ["query"]
+                }),
+            },
+            McpTool {
+                name: "utcp_call_tool_stream".to_string(),
+                description: Some("Call a UTCP tool with streaming response".to_string()),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "tool_name": {
+                            "type": "string",
+                            "description": "Name of the UTCP tool to call"
+                        },
+                        "arguments": {
+                            "type": "object",
+                            "description": "Arguments to pass to the tool"
+                        }
+                    },
+                    "required": ["tool_name"]
+                }),
+            },
+            McpTool {
+                name: "utcp_run_code".to_string(),
+                description: Some("Execute inline code via UTCP CodeMode engine".to_string()),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string",
+                            "description": "Rhai script to execute"
+                        },
+                        "timeout": {
+                            "type": "integer",
+                            "description": "Timeout in milliseconds",
+                            "default": 3000
+                        }
+                    },
+                    "required": ["code"]
+                }),
+            },
+        ]
+    }
+
+    /// Handle a JSON-RPC request
+    async fn handle_request(&self, request: JsonRpcRequest) -> JsonRpcResponse {
+        let id = request.id.clone();
+
+        match request.method.as_str() {
+            "initialize" => {
+                let result = json!({
+                    "protocolVersion": "2024-11-05",
+                    "serverInfo": {
+                        "name": "utcp-bridge",
+                        "version": "1.0.0"
+                    },
+                    "capabilities": {
+                        "tools": {}
+                    }
+                });
+
+                JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: Some(result),
+                    error: None,
+                }
+            }
+            "tools/list" => {
+                let tools = Self::get_tools();
+                JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: Some(json!({ "tools": tools })),
+                    error: None,
+                }
+            }
+            "tools/call" => self.handle_tool_call(id, request.params).await,
+            _ => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32601,
+                    message: format!("Method not found: {}", request.method),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    async fn handle_tool_call(&self, id: Option<Value>, params: Option<Value>) -> JsonRpcResponse {
+        let params = match params {
+            Some(p) => p,
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid params".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let tool_name = match params.get("name").and_then(|v| v.as_str()) {
+            Some(name) => name,
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Missing tool name".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let arguments = params
+            .get("arguments")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+
+        match tool_name {
+            "utcp_call_tool" => self.handle_utcp_call_tool(id, arguments).await,
+            "utcp_search_tools" => self.handle_utcp_search_tools(id, arguments).await,
+            "utcp_call_tool_stream" => self.handle_utcp_call_tool_stream(id, arguments).await,
+            "utcp_run_code" => self.handle_utcp_run_code(id, arguments).await,
+            _ => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32602,
+                    message: format!("Unknown tool: {}", tool_name),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    async fn handle_utcp_run_code(
+        &self,
+        id: Option<Value>,
+        arguments: serde_json::Map<String, Value>,
+    ) -> JsonRpcResponse {
+        let code = match arguments.get("code").and_then(|v| v.as_str()) {
+            Some(c) => c.to_string(),
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "code is required".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let timeout = arguments
+            .get("timeout")
+            .and_then(|v| v.as_u64())
+            .map(|t| t);
+
+        let args = CodeModeArgs {
+            code,
+            timeout,
+        };
+
+        match self.utcp_code.execute(args).await {
+            Ok(result) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: Some(json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string_pretty(&result.value).unwrap_or_else(|_| "{}".to_string())
+                    }]
+                })),
+                error: None,
+            },
+            Err(e) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: format!("Error executing code: {}", e),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    async fn handle_utcp_call_tool(
+        &self,
+        id: Option<Value>,
+        arguments: serde_json::Map<String, Value>,
+    ) -> JsonRpcResponse {
+        let tool_name = match arguments.get("tool_name").and_then(|v| v.as_str()) {
+            Some(name) => name,
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "tool_name is required".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let tool_args = arguments
+            .get("arguments")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<HashMap<String, Value>>()
+            })
+            .unwrap_or_default();
+
+        match self.utcp_client.call_tool(tool_name, tool_args).await {
+            Ok(result) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: Some(json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".to_string())
+                    }]
+                })),
+                error: None,
+            },
+            Err(e) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: format!("Error calling tool: {}", e),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    async fn handle_utcp_search_tools(
+        &self,
+        id: Option<Value>,
+        arguments: serde_json::Map<String, Value>,
+    ) -> JsonRpcResponse {
+        let query = match arguments.get("query").and_then(|v| v.as_str()) {
+            Some(q) => q,
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "query is required".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let limit = arguments
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10) as usize;
+
+        match self.utcp_client.search_tools(query, limit).await {
+            Ok(tools) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: Some(json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string_pretty(&tools).unwrap_or_else(|_| "[]".to_string())
+                    }]
+                })),
+                error: None,
+            },
+            Err(e) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: format!("Error searching tools: {}", e),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    async fn handle_utcp_call_tool_stream(
+        &self,
+        id: Option<Value>,
+        arguments: serde_json::Map<String, Value>,
+    ) -> JsonRpcResponse {
+        let tool_name = match arguments.get("tool_name").and_then(|v| v.as_str()) {
+            Some(name) => name,
+            None => {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "tool_name is required".to_string(),
+                        data: None,
+                    }),
+                }
+            }
+        };
+
+        let tool_args = arguments
+            .get("arguments")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<HashMap<String, Value>>()
+            })
+            .unwrap_or_default();
+
+        match self.utcp_client.call_tool_stream(tool_name, tool_args).await {
+            Ok(mut stream) => {
+                let mut chunks = Vec::new();
+
+                loop {
+                    match stream.next().await {
+                        Ok(Some(chunk)) => {
+                            chunks.push(chunk);
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            return JsonRpcResponse {
+                                jsonrpc: "2.0".to_string(),
+                                id,
+                                result: None,
+                                error: Some(JsonRpcError {
+                                    code: -32603,
+                                    message: format!("Stream error: {}", e),
+                                    data: None,
+                                }),
+                            };
+                        }
+                    }
+                }
+
+                JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: Some(json!({
+                        "content": [{
+                            "type": "text",
+                            "text": serde_json::to_string_pretty(&json!({ "chunks": chunks })).unwrap_or_else(|_| "{}".to_string())
+                        }]
+                    })),
+                    error: None,
+                }
+            }
+            Err(e) => JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32603,
+                    message: format!("Error calling tool stream: {}", e),
+                    data: None,
+                }),
+            },
+        }
+    }
+
+    /// Run the MCP server over stdio
+    pub async fn run(&self) -> Result<()> {
+        let stdin = tokio::io::stdin();
+        let mut stdout = tokio::io::stdout();
+        let reader = BufReader::new(stdin);
+        let mut lines = reader.lines();
+
+        info!("UTCP MCP Bridge is ready on stdio");
+
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            // Parse the JSON-RPC request
+            let request: JsonRpcRequest = match serde_json::from_str(&line) {
+                Ok(req) => req,
+                Err(e) => {
+                    error!("Failed to parse request: {}", e);
+                    let error_response = JsonRpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: None,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32700,
+                            message: format!("Parse error: {}", e),
+                            data: None,
+                        }),
+                    };
+                    let response_str = serde_json::to_string(&error_response)?;
+                    stdout.write_all(response_str.as_bytes()).await?;
+                    stdout.write_all(b"\n").await?;
+                    stdout.flush().await?;
+                    continue;
+                }
+            };
+
+            // Handle the request
+            let response = self.handle_request(request).await;
+
+            // Send the response
+            let response_str = serde_json::to_string(&response)?;
+            stdout.write_all(response_str.as_bytes()).await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr) // Write logs to stderr to avoid interfering with stdio protocol
+        .init();
+
+    info!("Starting UTCP MCP Bridge...");
+
+    // Create UTCP client config
+    let providers_file = std::env::var("UTCP_PROVIDERS_FILE").ok();
+    let mut config = UtcpClientConfig::default();
+    if let Some(path) = providers_file {
+        config.providers_file_path = Some(path.into());
+    }
+
+    // Create and run the bridge
+    let bridge = UtcpMcpBridge::new(config).await?;
+    bridge.run().await?;
+
+    info!("Bridge shutting down");
+    Ok(())
+}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Rust MCP bridge that exposes UTCP tools to any MCP client over stdio. Enables tool calls, search, streaming, and inline code execution.

- **New Features**
  - Stdio JSON-RPC MCP server with initialize, tools/list, and tools/call.
  - Tools: utcp_call_tool, utcp_search_tools, utcp_call_tool_stream, utcp_run_code (CodeMode/Rhai).
  - Provider loading via UTCP_PROVIDERS_FILE; includes providers.example.json.
  - Logs to stderr to avoid interfering with MCP I/O.
  - Documentation with install, usage, and examples.

<sup>Written for commit fe8c5b66ab43a818ecbc6424975b7a5916a55fdf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



