### PR TITLE
add dev scripts for local Claude Code MCP testing + install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,41 @@ Create a `.utcp_config.json` file to configure your tools and services:
 }
 ```
 
+### Claude Code (CLI)
+
+For [Claude Code](https://claude.com/claude-code) (the CLI / IDE extension), register the bridge as a user-scoped MCP server:
+
+```bash
+claude mcp add-json --scope user utcp '{"type":"stdio","command":"npx","args":["@utcp/mcp-bridge"],"env":{"UTCP_CONFIG_FILE":"/absolute/path/to/.utcp_config.json"}}'
+```
+
+Then restart Claude Code. Verify with `claude mcp list`. Remove with `claude mcp remove utcp --scope user`.
+
+## 🧪 Local development against the bridge
+
+If you're hacking on `@utcp/sdk` or any other [typescript-utcp](https://github.com/universal-tool-calling-protocol/typescript-utcp) package and want to exercise it through Claude Code, use the dev scripts:
+
+```bash
+cd utcp-mcp
+npm install
+npm run dev:register     # builds typescript-utcp packages, overlays each into the bridge's node_modules, builds the bridge, and registers it as 'utcp-dev' in Claude Code
+# restart Claude Code
+
+# After every edit:
+npm run dev:register     # rebuilds, re-registers; restart Claude Code
+
+# When done:
+npm run dev:unregister   # removes the MCP entry and restores registry node_modules
+```
+
+Both scripts are idempotent and never mutate `package.json`. The overlay strategy avoids `npm link`, which under modern npm aliases `unlink` to `uninstall --save` and would silently strip the dependency.
+
+The script expects the typescript-utcp checkout to live next to this repo (`../typescript-utcp`). Override with flags if not:
+
+- `--lib-dir <path>` — point at a different typescript-utcp checkout, or pass `none` to skip the overlay step entirely (useful when only editing the bridge)
+- `--name <mcp-name>` (default `utcp-dev`) — useful if you want the dev bridge alongside a published one
+- `--config <path>` (default `./.utcp_config.json`) — point at a different UTCP config
+
 ## 🛠️ Available MCP Tools
 
 The bridge exposes these MCP tools for managing your UTCP ecosystem:

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "utcp-mcp",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.20.2",
+        "@modelcontextprotocol/sdk": "~1.20.2",
         "@utcp/cli": "^1.0.12",
         "@utcp/dotenv-loader": "^1.0.0",
         "@utcp/file": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "node --max-old-space-size=8192 ./node_modules/typescript/bin/tsc",
     "prepublishOnly": "npm run build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "dev:register": "node scripts/dev-register.mjs",
+    "dev:unregister": "node scripts/dev-unregister.mjs"
   },
   "keywords": [
     "utcp",
@@ -46,7 +48,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.20.2",
+    "@modelcontextprotocol/sdk": "~1.20.2",
     "@utcp/cli": "^1.0.12",
     "@utcp/http": "^1.0.13",
     "@utcp/mcp": "^1.0.12",

--- a/scripts/dev-register.mjs
+++ b/scripts/dev-register.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Wire up the local utcp-mcp bridge as an MCP server in Claude Code.
+//
+// Optionally overlays locally-built typescript-utcp packages (sibling repo)
+// onto the bridge's node_modules so edits to @utcp/sdk, @utcp/http, etc. flow
+// through after a rebuild + Claude Code restart.
+//
+// Strategy: dist-overlay, not `npm link`. Modern npm aliases `unlink <pkg>` to
+// `uninstall --save`, which would silently strip dependencies from package.json.
+//
+// Usage:
+//   node scripts/dev-register.mjs [--name <mcp-name>] [--config <path>] [--lib-dir <path>]
+//
+// Defaults:
+//   --name     utcp-dev
+//   --config   ./.utcp_config.json (relative to bridge package)
+//   --lib-dir  ../typescript-utcp (sibling repo; pass "none" to skip overlay)
+
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const name = getArg("--name", "utcp-dev");
+const configPath = path.resolve(bridgeDir, getArg("--config", ".utcp_config.json"));
+const libDirArg = getArg("--lib-dir", "../typescript-utcp");
+const libDir = libDirArg === "none" ? null : path.resolve(bridgeDir, libDirArg);
+
+if (!existsSync(configPath)) {
+  console.error(`✗ Config file not found: ${configPath}`);
+  console.error(`  Pass --config <path> or create one at ${configPath}.`);
+  process.exit(1);
+}
+
+function run(cmd, cmdArgs, opts = {}) {
+  console.log(`> ${cmd} ${cmdArgs.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  const r = spawnSync(cmd, cmdArgs, { stdio: "inherit", shell: true, ...opts });
+  if (r.status !== 0) {
+    console.error(`✗ Command failed (exit ${r.status}).`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+// Prefer bun (this repo's native package manager — bun.lock is checked in).
+// Fall back to npm so contributors without bun installed still get a working
+// devloop.
+const bunAvailable = spawnSync("bun", ["--version"], { stdio: "ignore", shell: true }).status === 0;
+const pm = bunAvailable ? "bun" : "npm";
+
+// 1. Make sure the bridge has its registry deps installed.
+if (!existsSync(path.join(bridgeDir, "node_modules"))) {
+  run(pm, ["install"], { cwd: bridgeDir });
+}
+
+// 2. Optionally build typescript-utcp and overlay each package's dist into the
+//    bridge's node_modules. typescript-utcp is a bun-managed monorepo with one
+//    sub-package per directory under packages/.
+if (libDir) {
+  if (!existsSync(libDir) || !existsSync(path.join(libDir, "packages"))) {
+    console.warn(`⚠ --lib-dir ${libDir} doesn't look like typescript-utcp; skipping overlay.`);
+  } else {
+    run(pm, ["run", "build"], { cwd: libDir });
+
+    const pkgsDir = path.join(libDir, "packages");
+    const subdirs = readdirSync(pkgsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+
+    let overlayCount = 0;
+    for (const sub of subdirs) {
+      const pkgJsonPath = path.join(pkgsDir, sub, "package.json");
+      if (!existsSync(pkgJsonPath)) continue;
+      const pkgName = JSON.parse(readFileSync(pkgJsonPath, "utf8")).name;
+      if (!pkgName) continue;
+
+      const targetPkgDir = path.join(bridgeDir, "node_modules", ...pkgName.split("/"));
+      const localDist = path.join(pkgsDir, sub, "dist");
+      const targetDist = path.join(targetPkgDir, "dist");
+
+      if (!existsSync(targetPkgDir)) continue; // Bridge doesn't depend on this package.
+      if (!existsSync(localDist)) {
+        console.warn(`⚠ ${pkgName}: local dist missing at ${localDist}; skipping.`);
+        continue;
+      }
+
+      console.log(`> overlay  ${localDist}  ->  ${targetDist}`);
+      rmSync(targetDist, { recursive: true, force: true });
+      mkdirSync(targetDist, { recursive: true });
+      cpSync(localDist, targetDist, { recursive: true });
+      overlayCount++;
+    }
+    console.log(`  Overlaid ${overlayCount} package(s) from ${libDir}.`);
+  }
+} else {
+  console.log("• Skipping typescript-utcp overlay (--lib-dir none).");
+}
+
+// 3. Build the bridge against the (possibly overlaid) deps.
+run(pm, ["run", "build"], { cwd: bridgeDir });
+
+// 4. Register with Claude Code (user scope). Removes a stale entry first so
+//    the command is idempotent.
+spawnSync("claude", ["mcp", "remove", name, "--scope", "user"], {
+  stdio: "ignore",
+  shell: true,
+});
+
+const distEntry = path.join(bridgeDir, "dist", "index.js").replace(/\\/g, "/");
+const cfg = configPath.replace(/\\/g, "/");
+const mcpJson = JSON.stringify({
+  type: "stdio",
+  command: "node",
+  args: [distEntry],
+  env: { UTCP_CONFIG_FILE: cfg },
+});
+
+const isWindows = os.platform() === "win32";
+const quotedJson = isWindows
+  ? `"${mcpJson.replace(/"/g, '\\"')}"`
+  : `'${mcpJson.replace(/'/g, `'\\''`)}'`;
+
+const cmdLine = `claude mcp add-json --scope user ${name} ${quotedJson}`;
+console.log(`> ${cmdLine}`);
+const r = spawnSync(cmdLine, { stdio: "inherit", shell: true });
+if (r.status !== 0) {
+  console.error(`✗ claude mcp add-json failed (exit ${r.status}).`);
+  process.exit(r.status ?? 1);
+}
+
+console.log(`\n✓ Registered MCP server '${name}' (user scope).`);
+console.log(`  Entry:  ${distEntry}`);
+console.log(`  Config: ${cfg}`);
+console.log(`\nRestart Claude Code to load the server. After editing the bridge or any`);
+console.log(`typescript-utcp package, re-run this script then restart Claude Code.`);

--- a/scripts/dev-unregister.mjs
+++ b/scripts/dev-unregister.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Tear down what dev-register.mjs set up: deregister the Claude Code MCP server
+// and restore the registry versions of any typescript-utcp packages whose dist
+// dirs were overlaid in node_modules.
+//
+// Usage:
+//   node scripts/dev-unregister.mjs [--name <mcp-name>]
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const getArg = (flag, fallback) => {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const name = getArg("--name", "utcp-dev");
+
+function run(cmd, cmdArgs, opts = {}) {
+  console.log(`> ${cmd} ${cmdArgs.join(" ")}  (in ${opts.cwd ?? process.cwd()})`);
+  spawnSync(cmd, cmdArgs, { stdio: "inherit", shell: true, ...opts });
+}
+
+run("claude", ["mcp", "remove", name, "--scope", "user"]);
+
+// Prefer bun to match this repo's native package manager (bun.lock is checked
+// in); fall back to npm. Reinstall from the registry to undo any dist-overlay.
+const bunAvailable = spawnSync("bun", ["--version"], { stdio: "ignore", shell: true }).status === 0;
+if (bunAvailable) {
+  run("bun", ["install"], { cwd: bridgeDir });
+} else {
+  // npm install --no-save keeps package.json untouched.
+  run("npm", ["install", "--no-save"], { cwd: bridgeDir });
+}
+
+console.log(`\n✓ Unregistered '${name}' and restored registry node_modules.`);
+console.log(`  Restart Claude Code so it stops trying to spawn the dev bridge.`);


### PR DESCRIPTION
- scripts/dev-{register,unregister}.mjs: build typescript-utcp packages in a sibling checkout, overlay each package's dist into the bridge's node_modules, build the bridge, and (un)register it with `claude mcp add-json --scope user`. Uses bun when available (matches this repo's native package manager) and falls back to npm. Idempotent and never mutates package.json. Avoids `npm link` because modern npm aliases `unlink <pkg>` to `uninstall --save`, which silently strips the dependency.

- README: add a `claude mcp add-json` snippet for Claude Code users alongside the existing Claude Desktop one, plus a "Local development against the bridge" section describing `npm run dev:register` / `dev:unregister` and the `--lib-dir` / `--name` / `--config` flags.

- package.json: bump tsc heap to 8 GB (matches code-mode-mcp; the default 4 GB OOMs on the SDK type graph), pin @modelcontextprotocol/sdk to ~1.20.2 (1.29.x triggers TS2589 excessive-depth errors in registerTool inputSchema inference), and expose the new dev scripts via npm/bun run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dev scripts to register/unregister the MCP bridge for Claude Code and make local testing against `typescript-utcp` easy. Also add CLI install docs and pin build settings for stability.

- **New Features**
  - `npm run dev:register`: builds local `typescript-utcp`, overlays `dist` into the bridge’s `node_modules`, builds the bridge, and registers a user-scoped MCP server via `claude mcp add-json`. Flags: `--lib-dir`, `--name`, `--config`. Prefers bun; idempotent; avoids `npm link`.
  - `npm run dev:unregister`: removes the MCP entry and reinstalls registry deps to undo overlays.
  - README: adds Claude Code (CLI) install snippet and a short local dev guide.

- **Dependencies**
  - Pin `@modelcontextprotocol/sdk` to `~1.20.2` to avoid TS2589 errors; update `bun.lock`.
  - Increase tsc heap to 8 GB to avoid OOM on the SDK type graph.
  - Expose `dev:register` and `dev:unregister` in `package.json`.

<sup>Written for commit a845b7d8178719c8f8cf3fc1145c5fb832433228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

